### PR TITLE
Don't re-open hidden tree-view after reload

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-widget.ts
@@ -70,13 +70,15 @@ export class PluginViewWidget extends Panel implements StatefulWidget {
         return {
             label: this.title.label,
             message: this.message,
-            widgets: this.widgets
+            widgets: this.widgets,
+            suppressVisibilityClause: this._suppressUpdateViewVisibility
         };
     }
 
     restoreState(state: PluginViewWidget.State): void {
         this.title.label = state.label;
         this.message = state.message;
+        this.suppressUpdateViewVisibility = state.suppressVisibilityClause;
         for (const widget of state.widgets) {
             this.addWidget(widget);
         }
@@ -131,8 +133,9 @@ export class PluginViewWidget extends Panel implements StatefulWidget {
 }
 export namespace PluginViewWidget {
     export interface State {
-        label: string
-        message?: string;
-        widgets: ReadonlyArray<Widget>
+        label: string,
+        message?: string,
+        widgets: ReadonlyArray<Widget>,
+        suppressVisibilityClause: boolean
     }
 }


### PR DESCRIPTION
The PluginViewWidget has a property to suppress visibility updates
from a `when` clause in the case a user specifically requests to hide
it. However when the browser reloaded, the flag was reset to default
and the prvided `when` clause would apply to decide the visibility.

This change preserves the flag mentioned above in the PluginViewWidget
state, this state is presered and then available for use in
`restoreState` where the flag is now updated to the state before the
browser reload.

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

